### PR TITLE
ci: add shellcheck and syntax check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        run: |
+          files=$(git ls-files '*.sh')
+          if [ -n "$files" ]; then
+            shellcheck $files
+          fi
+      - name: Bash syntax check
+        run: |
+          files=$(git ls-files '*.sh')
+          if [ -n "$files" ]; then
+            bash -n $files
+          fi


### PR DESCRIPTION
## Summary
- add workflow running ShellCheck and bash syntax checks

## Testing
- `bash -n bluezfuncs.sh`
- `shellcheck bluezfuncs.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adfab1d24c8320a8ef185c70ba4033